### PR TITLE
ci: group dependabot updates by semver level and skip majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      github-actions-minor:
+        update-types:
+          - 'minor'
+      github-actions-patch:
+        update-types:
+          - 'patch'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   # Maintain dependencies for NPM
   - package-ecosystem: 'npm'
@@ -22,6 +32,16 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      npm-minor:
+        update-types:
+          - 'minor'
+      npm-patch:
+        update-types:
+          - 'patch'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   # Maintain dependencies for Docker
   - package-ecosystem: 'docker'
@@ -33,3 +53,13 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      docker-minor:
+        update-types:
+          - 'minor'
+      docker-patch:
+        update-types:
+          - 'patch'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,15 @@ updates:
     labels:
       - 'dependencies'
     groups:
+      github-actions-major:
+        update-types:
+          - 'major'
       github-actions-minor:
         update-types:
           - 'minor'
       github-actions-patch:
         update-types:
           - 'patch'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
 
   # Maintain dependencies for NPM
   - package-ecosystem: 'npm'


### PR DESCRIPTION
## Summary
Configure Dependabot to open grouped PRs instead of one PR per dependency, and stop opening PRs for major version updates on npm and Docker so breaking upgrades are handled manually. GitHub Actions majors stay enabled (Actions are tagged with major-only versions, so ignoring them would disable all Actions updates) and arrive as a grouped PR.

## Changes
- Add `groups` to all three ecosystems: minor bumps are combined into one PR and patch bumps into another, per ecosystem
- Add a `github-actions-major` group so Actions major bumps arrive as a single grouped PR instead of one PR each
- Add an `ignore` rule (`dependency-name: '*'` + `version-update:semver-major`) to npm and Docker so no major-version PRs are opened for those ecosystems

## Test plan
- [x] YAML syntax validated locally with js-yaml
- [ ] After merge, wait for the next monthly Dependabot run and confirm PRs arrive grouped as `<ecosystem>-minor` / `<ecosystem>-patch` (plus `github-actions-major`), with no npm/Docker major bumps